### PR TITLE
Stomp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Production wrapper for pilot2
+Production wrapper for Pilot 3

--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -786,6 +786,20 @@ function main() {
   fi
   echo
 
+  echo "---- Setup stomp ----"
+  result=$(get_catchall)
+  if [[ $? -eq 0 ]]; then
+    if grep -q "messaging=stomp" <<< "$result"; then
+      log 'Stomp requested via CRIC catchall, running lsetup stomp'
+      lsetup stomp
+    else
+      log 'Stomp not requested in CRIC catchall'
+    fi
+  else
+    log 'No content found in CRIC catchall'
+  fi
+  echo
+
 
   if [[ ${harvesterflag} == 'true' ]]; then
     echo "---- Create symlinks to input data ----"

--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -4,7 +4,7 @@
 #
 # https://google.github.io/styleguide/shell.xml
 
-VERSION=20220615a-master
+VERSION=20220726a-master
 
 function err() {
   dt=$(date --utc +"%Y-%m-%d %H:%M:%S,%3N [wrapper]")


### PR DESCRIPTION
Added setup for stomp.py
- if 'messaging=stomp' is present in PQ.catchall, wrapper will execute 'lsetup stomp'
- needed for sPHENIX, who are using the same wrapper, in the context of prompt processing (a faster way of sending a job to a pilot). Eventually we will want to use it in ATLAS as well
- wrapper has been tested on queues with and without catchall instruction