### PR TITLE
Always use queuedata.json when present

### DIFF
--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -525,11 +525,7 @@ function check_singularity() {
 }
 
 function check_type() {
-  if [[ -f queuedata.json ]]; then
-    result=$(cat queuedata.json | grep container_type | grep 'singularity:wrapper')
-  else
-    result=$(curl --silent $cricurl | grep container_type | grep 'singularity:wrapper')
-  fi
+  result=$(curl --silent $cricurl | grep container_type | grep 'singularity:wrapper')
   if [[ $? -eq 0 ]]; then
     log "CRIC container_type: singularity:wrapper found"
     return 0
@@ -1015,7 +1011,12 @@ if [ -z "${qarg}" ]; then usage; exit 1; fi
 
 pilotargs="$@"
 
-cricurl="http://pandaserver.cern.ch:25085/cache/schedconfig/${sarg}.all.json"
+if [[ -f queuedata.json ]]; then
+  cricurl="file://${PWD}/queuedata.json"
+else
+  cricurl="http://pandaserver.cern.ch:25085/cache/schedconfig/${sarg}.all.json"
+fi
+
 fabricmon="http://apfmon.lancs.ac.uk/api"
 if [ -z ${APFMON} ]; then
   APFMON=${fabricmon}


### PR DESCRIPTION
Use queuedata.json in all cases where CRIC info is queried, so that it works on worker nodes without network access.