### PR TITLE
CVMFSExec support

### DIFF
--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -100,7 +100,7 @@ function setup_python3() {
   else
     log "Using ALRB to setup python3"
     if [ -z "$ATLAS_LOCAL_ROOT_BASE" ]; then
-        export ATLAS_LOCAL_ROOT_BASE="$ATLAS_SW_BASE/atlas.cern.ch/repo/ATLASLocalRootBase"
+        export ATLAS_LOCAL_ROOT_BASE="${ATLAS_SW_BASE}/atlas.cern.ch/repo/ATLASLocalRootBase"
     fi
     export ALRB_LOCAL_PY3="YES"
     source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh --quiet
@@ -161,7 +161,7 @@ function check_proxy() {
 }
 
 function check_cvmfs() {
-  export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-$ATLAS_SW_BASE/atlas.cern.ch/repo/sw}
+  export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/sw}
   if [[ -d ${VO_ATLAS_SW_DIR} ]]; then
     log "Found atlas software repository: ${VO_ATLAS_SW_DIR}"
   else
@@ -183,7 +183,7 @@ function setup_alrb() {
     log 'ALRB pilot requested, setting ALRB env vars to testing'
     export ALRB_adcTesting=YES
   fi
-  export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-$ATLAS_SW_BASE/atlas.cern.ch/repo/ATLASLocalRootBase}
+  export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/ATLASLocalRootBase}
   export ALRB_userMenuFmtSkip=YES
   export ALRB_noGridMW=${ALRB_noGridMW:-NO}
 
@@ -318,7 +318,7 @@ function sing_env() {
 
 function get_piloturl() {
   local version=$1
-  local pilotdir=file://$ATLAS_SW_BASE/atlas.cern.ch/repo/sw/PandaPilot/tar
+  local pilotdir=file://${ATLAS_SW_BASE}/atlas.cern.ch/repo/sw/PandaPilot/tar
 
   if [[ -n ${piloturl} ]]; then
     echo ${piloturl}
@@ -521,12 +521,12 @@ function check_singularity() {
     # to it specifically for CVMFSExec. The relocatable binary functionality we
     # depend on is not available in Singularity. The interface should otherwise
     # be the same as singularity.
-    BINARY_PATH="/cvmfs/atlas.cern.ch/repo/containers/sw/apptainer/`uname -m`-el7/current/bin/apptainer"
+    BINARY_PATH="${ATLAS_SW_BASE}/atlas.cern.ch/repo/containers/sw/apptainer/`uname -m`-el7/current/bin/apptainer"
   else
-    BINARY_PATH="/cvmfs/atlas.cern.ch/repo/containers/sw/singularity/`uname -m`-el7/current/bin/singularity"
+    BINARY_PATH="${ATLAS_SW_BASE}/atlas.cern.ch/repo/containers/sw/singularity/`uname -m`-el7/current/bin/singularity"
   fi
-  IMAGE_PATH="/cvmfs/atlas.cern.ch/repo/containers/fs/singularity/`uname -m`-centos7"
-  SINGULARITY_OPTIONS="$(get_cricopts) -B $ATLAS_SW_BASE:/cvmfs -B $PWD --cleanenv"
+  IMAGE_PATH="${ATLAS_SW_BASE}/atlas.cern.ch/repo/containers/fs/singularity/`uname -m`-centos7"
+  SINGULARITY_OPTIONS="$(get_cricopts) -B ${ATLAS_SW_BASE}:/cvmfs -B $PWD --cleanenv"
   out=$(${BINARY_PATH} --version 2>/dev/null)
   if [[ $? -eq 0 ]]; then
     log "Singularity binary found, version $out"
@@ -720,8 +720,8 @@ function main() {
     log 'Skipping defining VO_ATLAS_SW_DIR due to --container flag'
     log 'Skipping defining ATLAS_LOCAL_ROOT_BASE due to --container flag'
   else
-    export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-$ATLAS_SW_BASE/atlas.cern.ch/repo/sw}
-    export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-$ATLAS_SW_BASE/atlas.cern.ch/repo/ATLASLocalRootBase}
+    export VO_ATLAS_SW_DIR=${VO_ATLAS_SW_DIR:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/sw}
+    export ATLAS_LOCAL_ROOT_BASE=${ATLAS_LOCAL_ROOT_BASE:-${ATLAS_SW_BASE}/atlas.cern.ch/repo/ATLASLocalRootBase}
   fi
   echo
 


### PR DESCRIPTION
This work-in-progress PR adds CVMFSExec support to the pilot wrapper. It assumes that CVMFSExec has already been set up before the pilot wrapper starts, and that the path to the base directory is provided to the pilot wrapper via a new commandline flag, `--cvmfsbase`. It also assumes that the CVMFSExec unmount/cleanup will be handled outside of the pilot wrapper after the wrapper exits.

If the flag `--cvmfsbase` is provided, the argument to the flag is exported as `ATLAS_SW_BASE`. The default value of the `--cvmfsbase` is `/cvmfs`. Nearly all other instances of `/cvmfs` in the wrapper have been replaced with `$ATLAS_SW_BASE`. 

To use containers with CVMFSExec in this manner, we require Apptainer as provided via CVMFS rather than the usual singularity binary. Rather than broadly changing the pilot wrapper to use Apptainer everywhere, I have carved out a small conditional to only use Apptainer when CVMFSExec is being used. 

When we invoke singularity, we bind CVMFS to the usual place via `-B $ATLAS_SW_BASE:/cvmfs`. This way, the pilot environment inside of the container doesn't see a change. 

To accommodate this, the `$ATLAS_SW_BASE` variable is set explicitly to `/cvmfs` if the `$SINGULARITY_ENVIRONMENT` environment variable is set.

I have been fairly conservative about adding new logging statements but have tried to be generous with comments in the code. This has been tested with HammerCloud tasks and appears to be working. I have not tried it for workloads that run in the usual non-CVMFSExec way. 

Happy to make any changes needed per your feedback.