### PR TITLE
Migrate updateWorkerPilotStatus to new API

### DIFF
--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -663,12 +663,10 @@ function panda_update_worker_pilot_status() {
        --cacert "${X509_USER_PROXY}" --cert "${X509_USER_PROXY}" --key "${X509_USER_PROXY}" \
        -H "User-Agent: pilot-wrapper/${VERSION} ($(uname -sm))" \
        -H 'Accept: application/json' \
-       --data-urlencode "workerID=${HARVESTER_WORKER_ID}" \
-       --data-urlencode "harvesterID=${HARVESTER_ID}" \
-       --data-urlencode 'status=started' \
-       --data-urlencode "site=${qarg}" \
-       --data-urlencode "node_id=$(hostname -f)" \
-       "${pandaurl}/server/panda/updateWorkerPilotStatus"
+       -H 'Content-Type: application/json' \
+       -X POST \
+       -d "{\"worker_id\": ${HARVESTER_WORKER_ID}, \"harvester_id\": \"${HARVESTER_ID}\", \"status\": \"started\", \"node_id\": \"$(hostname -f)\"}" \
+       "${pandaurl}/api/v1/pilot/update_worker_status"
 }
 
 function hostinfo() {


### PR DESCRIPTION
Hi @ptrlv , 
We are migrating to a new PanDA server API and I've seen this old call. Can you please release a new wrapper version with the update? 
I've tested the change standalone, not within the wrapper. It would be good if you could validate it as well.
Thanks,
Fernando