### PR TITLE
Support --queuedata-url for queuedata resolution instead of relying on the hardcoded pandaserver.cern.ch schedconfig endpoint

### DIFF
--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -1184,6 +1184,11 @@ case $key in
     shift
     shift
     ;;
+    --queuedata-url)
+    queuedata_url="$2"
+    shift
+    shift
+    ;;
     -i)
     iarg="$2"
     shift
@@ -1236,6 +1241,8 @@ pilotargs="$@"
 
 if [[ -f queuedata.json ]]; then
   cricurl="file://${PWD}/queuedata.json"
+elif [[ -n "${queuedata_url}" ]]; then
+  cricurl="${queuedata_url}"
 else
   cricurl="http://pandaserver.cern.ch:25085/cache/schedconfig/${qarg}.all.json"
 fi

--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -1186,6 +1186,8 @@ case $key in
     ;;
     --queuedata-url)
     queuedata_url="$2"
+    POSITIONAL+=("$1")
+    POSITIONAL+=("$2")
     shift
     shift
     ;;


### PR DESCRIPTION
Hi @ptrlv,

Add support for `--queuedata-url` in `runpilot2-wrapper.sh` and use it for queuedata resolution.

Previously, the wrapper resolved queuedata only from a local `queuedata.json` file or the hardcoded `pandaserver.cern.ch` schedconfig endpoint. This required mounting `queuedata.json` into pilot job templates for custom deployments.

This change:

* parses `--queuedata-url` in the wrapper
* preserves the argument so it continues to be forwarded to the pilot
* allows queuedata to be resolved directly from the provided URL without requiring a local `queuedata.json` mount

Existing fallback behavior remains unchanged.
